### PR TITLE
Adjust default configuration to avoid failing readiness/liveness probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Always enable fluent-bit's HTTP server for readiness/liveness probes ([#2])
+- Patch containerPort in DaemonSet when metrics port is customized ([#2])
 - Initial Implementation ([#1])
 
 [Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/v0.1.0...HEAD
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
+[#2]: https://github.com/projectsyn/component-fluentbit/pull/2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Patch containerPort in DaemonSet when metrics port is customized ([#2])
 - Initial Implementation ([#1])
 
-[Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/50f0caf4c8718ca57f09c8bff71c8518717ce6d3...HEAD
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
 [#2]: https://github.com/projectsyn/component-fluentbit/pull/2

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -14,7 +14,7 @@ local render_fluentbit_cfg(type, name, cfg) =
     else
       name;
   // remove 'Name' entry from `cfg` object, if it exists
-  local realcfg = std.prune(cfg + {Name: null});
+  local realcfg = std.prune(cfg { Name: null });
   local entries = std.prune([
     // explicitly add 'Name' key as first element of section
     if realname != '' then std.format('Name %s', realname),

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,7 +50,7 @@ local serviceCfg = {
   Daemon: 'Off',
   Plugins_File: 'plugins.conf',
   HTTP_Listen: '0.0.0.0',
-  HTTP_Server: if params.monitoring.enabled then 'On' else 'Off',
+  HTTP_Server: 'On',
   HTTP_Port: params.monitoring.metricsPort,
 } + params.config.service;
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -22,6 +22,13 @@ Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and
 The respective keys are `service`, `inputs`, `outputs`, `filters`, and
 `parsers`.
 
+[NOTE]
+====
+Fluent-bit uses the strings 'On' and 'Off' for boolean configuration values.
+Make sure that you quote those strings to avoid them getting interpreted as
+booleans when the hierarchy YAML is parsed.
+====
+
 == `config.service`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -33,6 +33,10 @@ See
 https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[the
 upstream documentation] for available configuration parameters.
 
+Please note that 'HTTP_Server' should not be disabled, as otherwise the
+container readiness and liveness probes will fail, and the pods will go into
+CrashLoopBackOff.
+
 The contents of this key will be reproduced verbatim (including capitalization
 of keys and values) in the fluent-bit configuration file in section
 `[SERVICE]`.

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -5,3 +5,6 @@ filters:
     filterargs:
       namespace: ${fluentbit:namespace}
       create_namespace: "true"
+  - output_path: fluentbit/01_fluentbit_helmchart/fluent-bit/templates
+    type: jsonnet
+    filter: patch_helm_output.jsonnet

--- a/postprocess/patch_helm_output.jsonnet
+++ b/postprocess/patch_helm_output.jsonnet
@@ -1,0 +1,55 @@
+local com = import 'lib/commodore.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = com.inventory();
+local params = inv.parameters.fluentbit;
+
+local chart_output_dir = std.extVar('output_path');
+
+local list_dir(dir, basename=true) =
+  std.native('list_dir')(dir, basename);
+
+local chart_files = list_dir(chart_output_dir);
+
+local input_file(elem) = chart_output_dir + '/' + elem;
+local stem(elem) =
+  local elems = std.split(elem, '.');
+  std.join('.', elems[:std.length(elems) - 1]);
+
+local fix_container_port(ds) =
+  local ports = ds.spec.template.spec.containers[0].ports;
+  local fixedports = [
+    if p.name == 'http' then
+      p + { containerPort: params.monitoring.metricsPort }
+    else
+      p
+    for p in ports
+  ];
+  ds {
+    spec+: {
+      template+: {
+        spec+: {
+          containers: [
+            ds.spec.template.spec.containers[0] {
+              ports: fixedports,
+            },
+          ],
+        },
+      },
+    },
+  };
+
+local fixup_obj(obj) =
+  if obj.kind == 'DaemonSet' then
+    fix_container_port(obj)
+  else
+    obj;
+
+local fixup(obj_file) =
+  local objs = std.prune(com.yaml_load_all(obj_file));
+  [fixup_obj(obj) for obj in objs];
+
+{
+  [stem(elem)]: fixup(input_file(elem))
+  for elem in chart_files
+}

--- a/postprocess/patch_helm_output.jsonnet
+++ b/postprocess/patch_helm_output.jsonnet
@@ -20,7 +20,7 @@ local fix_container_port(ds) =
   local ports = ds.spec.template.spec.containers[0].ports;
   local fixedports = [
     if p.name == 'http' then
-      p + { containerPort: params.monitoring.metricsPort }
+      p { containerPort: params.monitoring.metricsPort }
     else
       p
     for p in ports


### PR DESCRIPTION
* Always have HTTP_Server enabled for liveness/readiness probe.
* Patch containerPort in DaemonSet if custom metricsPort is requested.

## Checklist
- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
