### PR TITLE
Ensure DaemonSet pods are restarted when config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Restart fluent-bit pods when the custom config changes ([#3])
 - Always enable fluent-bit's HTTP server for readiness/liveness probes ([#2])
 - Patch containerPort in DaemonSet when metrics port is customized ([#2])
 - Initial Implementation ([#1])
 
+### Fixed
+
+- Properly quote 'On' and 'Off' values in `class/defaults.yml`
+
 [Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/50f0caf4c8718ca57f09c8bff71c8518717ce6d3...HEAD
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
 [#2]: https://github.com/projectsyn/component-fluentbit/pull/2
+[#3]: https://github.com/projectsyn/component-fluentbit/pull/3

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -3,4 +3,7 @@
 fluentbit is a Commodore component to manage fluent-bit using the official
 https://hub.helm.sh/charts/fluent/fluent-bit[fluent/fluent-bit helm chart].
 
+The component adds a custom annotation `checksum/syn-config` to the PodSpec of the fluent-bit DaemonSet.
+This ensures that the fluent-bit pods are restarted when the configuration managed by the component changes.
+
 See the xref:references/parameters.adoc[parameters] reference for further details.


### PR DESCRIPTION
Since we're not using the Helm chart mechanism for configuring fluent-bit, but rather provide our own configmap, the built-in
checksumming of the config in the Helm chart does not trigger pod restarts when our custom config changes.

This commit introduces a second annotation on the DaemonSet podspec, which is set to the MD5 sum of the contents of our custom config file (syn-fluent-bit.conf in configmap syn-fluentbit-config).

This extra annotation should trigger pod restarts when our custom configuration changes.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
