### PR TITLE
Ensure filters are added to fluent-bit config in predictable order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Properly quote 'On' and 'Off' values in `class/defaults.yml`
+- Ensure filters are added to fluent-bit config in predictable order ([#6])
 
 [Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/50f0caf4c8718ca57f09c8bff71c8518717ce6d3...HEAD
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
 [#2]: https://github.com/projectsyn/component-fluentbit/pull/2
 [#3]: https://github.com/projectsyn/component-fluentbit/pull/3
+[#6]: https://github.com/projectsyn/component-fluentbit/pull/6

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -37,7 +37,8 @@ parameters:
       parsers: {}
       # The kubernetes filter is almost always wanted
       filters:
-        kubernetes:
+        00_kubernetes:
+          Name: kubernetes
           Match: kube.*
           # Extract log elements and add them as top-level keys
           Merge_Log: 'On'

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -43,7 +43,7 @@ local parsers = std.join('\n', [
 
 local filters = std.join('\n', [
   render_fluentbit_cfg('FILTER', elem, params.config.filters[elem])
-  for elem in std.objectFields(params.config.filters)
+  for elem in std.sort(std.objectFields(params.config.filters))
 ]);
 
 local serviceCfg = {

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -69,7 +69,7 @@ having multiple inputs using the same plugin.
 
 [horizontal]
 type:: dict
-default:: `{'kubernetes:'{'Match': 'kube.*', 'Merge_Log': 'On', 'Keep_Log': 'On', 'K8S-Logging.Parser': 'On', 'K8S-Logging.Exclude': 'On'}}`
+default:: `{'00_kubernetes:'{'Name': 'kubernetes', 'Match': 'kube.*', 'Merge_Log': 'On', 'Keep_Log': 'On', 'K8S-Logging.Parser': 'On', 'K8S-Logging.Exclude': 'On'}}`
 
 Configure fluent-bit filters.
 `config.filters` should have one key per `[FILTER]` section that should be
@@ -81,6 +81,11 @@ If the dict for a section doesn't have a key `Name`, the key for the section
 will be used as the plugin name for the section.
 This allows avoiding repetition, when it's unnecessary, while still supporting
 having multiple filters using the same plugin.
+
+NOTE: Please note that filter order matters to fluent-bit.
+The component will always output filters sorted by their keys.
+This behavior can be used to define sort order by prefixing keys in filters with a number (e.g. `00_kubernetes` would come before `10_modify`).
+When prefixing keys like this, the `Name` field must be provided, as fluent-bit won't know which filter plugin to use otherwise.
 
 == `config.parsers`
 


### PR DESCRIPTION
Add filters in sorted order according to their keys in `parameters.fluentbit.filters`.

Resolves #5.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
