### PR TITLE
Create ServiceMonitor manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Create ServiceMonitor manually ([#9])
 - Properly quote 'On' and 'Off' values in `class/defaults.yml`
 - Ensure filters are added to fluent-bit config in predictable order ([#6])
 
@@ -29,3 +30,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#6]: https://github.com/projectsyn/component-fluentbit/pull/6
 [#7]: https://github.com/projectsyn/component-fluentbit/pull/7
 [#8]: https://github.com/projectsyn/component-fluentbit/pull/8
+[#9]: https://github.com/projectsyn/component-fluentbit/pull/9


### PR DESCRIPTION
Since the Helm chart won't render it if the `.Capabilities.APIVersions`
parameter doesn't include `"monitoring.coreos.com/v1"`.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
