### PR TITLE
Implement support for repeatable fluent-bit options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v1.0.0]
 ### Added
 
+- Support for repeatable fluent-bit options ([#11])
 - Restart fluent-bit pods when the custom config changes ([#3])
 - Always enable fluent-bit's HTTP server for readiness/liveness probes ([#2])
 - Patch containerPort in DaemonSet when metrics port is customized ([#2])
@@ -24,7 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Properly quote 'On' and 'Off' values in `class/defaults.yml`
 - Ensure filters are added to fluent-bit config in predictable order ([#6])
 
-[Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/50f0caf4c8718ca57f09c8bff71c8518717ce6d3...HEAD
+[Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/projectsyn/component-fluentbit/releases/tag/v1.0.0
+
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
 [#2]: https://github.com/projectsyn/component-fluentbit/pull/2
 [#3]: https://github.com/projectsyn/component-fluentbit/pull/3
@@ -33,3 +38,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/projectsyn/component-fluentbit/pull/8
 [#9]: https://github.com/projectsyn/component-fluentbit/pull/9
 [#10]: https://github.com/projectsyn/component-fluentbit/pull/10
+[#11]: https://github.com/projectsyn/component-fluentbit/pull/11

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DOCKER_CMD   ?= docker
 DOCKER_ARGS  ?= run --rm --user "$$(id -u)" -v "$${PWD}:/component" --workdir /component
 
 JSONNET_FILES   ?= $(shell find . -type f -name '*.*jsonnet' -or -name '*.libsonnet')
-JSONNETFMT_ARGS ?= --in-place
+JSONNETFMT_ARGS ?= --in-place --pad-arrays
 JSONNET_IMAGE   ?= docker.io/bitnami/jsonnet:latest
 JSONNET_DOCKER  ?= $(DOCKER_CMD) $(DOCKER_ARGS) --entrypoint=jsonnetfmt $(JSONNET_IMAGE)
 

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -19,11 +19,11 @@ local render_fluentbit_cfg(type, name, cfg) =
     // explicitly add 'Name' key as first element of section
     if realname != '' then std.format('Name %s', realname),
   ] + [
-    std.format('%s %s', [key, realcfg[key]])
+    std.format('%s %s', [ key, realcfg[key] ])
     for key in std.objectFields(realcfg)
   ]);
   local entriesStr = std.join('\n    ', entries);
-  std.format('%s\n    %s', [header, entriesStr]);
+  std.format('%s\n    %s', [ header, entriesStr ]);
 
 
 local inputs = std.join('\n', [
@@ -69,7 +69,7 @@ local configmap = kube.ConfigMap(params.configMapName) {
     },
   },
   data: {
-    'fluent-bit.conf': std.join('\n', [service, parsers, filters, inputs, outputs]),
+    'fluent-bit.conf': std.join('\n', [ service, parsers, filters, inputs, outputs ]),
     'custom_parsers.conf': '',
   },
 };
@@ -90,10 +90,10 @@ local configmap = kube.ConfigMap(params.configMapName) {
         },
       },
       spec: {
-        endpoints: [{
+        endpoints: [ {
           port: 'http',
           path: '/api/v1/metrics/prometheus',
-        }],
+        } ],
         selector: {
           matchLabels: {
             'app.kubernetes.io/name': 'fluent-bit',

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -80,6 +80,7 @@ default:: `{'containers': {'Name': 'tail', 'Path': '/var/log/containers/*.log', 
 
 Configure fluent-bit inputs.
 `config.inputs` should have one key per `[INPUT]` section that should be added to the fluent-bit configuration file.
+
 Each key of `config.inputs` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
 If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
 This allows avoiding repetition, when it's unnecessary, while still supporting having multiple inputs using the same plugin.
@@ -92,15 +93,20 @@ default:: `{'00_kubernetes:'{'Name': 'kubernetes', 'Match': 'kube.*', 'Merge_Log
 
 Configure fluent-bit filters.
 `config.filters` should have one key per `[FILTER]` section that should be added to the fluent-bit configuration file.
+
 Each key of `config.filters` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including
 capitalization of keys and values).
 If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
 This allows avoiding repetition, when it's unnecessary, while still supporting having multiple filters using the same plugin.
 
-NOTE: Please note that filter order matters to fluent-bit.
+[NOTE]
+====
+Please note that filter order matters to fluent-bit.
 The component will always output filters sorted by their keys.
+
 This behavior can be used to define sort order by prefixing keys in filters with a number (for example `00_kubernetes` would come before `10_modify`).
 When prefixing keys like this, the `Name` field must be provided, as fluent-bit won't know which filter plugin to use otherwise.
+====
 
 == `config.parsers`
 
@@ -111,11 +117,13 @@ default:: `{}`
 Configure fluent-bit parsers.
 The component doesn't configure any custom parsers.
 However, fluent-bit already provides a multitude of parsers in the docker image.
+
 Those parsers are made available by default as key `Parsers_File` in the service section is set to `parsers.conf`.
 The parsers provided by that file be inspected on https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[GitHub].
 
 `config.parsers` should have one key per `[PARSER]` section that should be added to the fluent-bit configuration file.
 Each key of `config.parsers` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
+
 If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
 This allows avoiding repetition, when it's unnecessary, while still supporting having multiple parsers using the same plugin.
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,6 +25,40 @@ Fluent-bit uses the strings 'On' and 'Off' for boolean configuration values.
 Make sure that you quote those strings to avoid them getting interpreted as booleans when the hierarchy YAML is parsed.
 ====
 
+=== Repeatable fluent-bit options
+
+Repeatable fluent-bit options can be configured by giving them as lists under the repeatable option's key:
+
+[source,yaml]
+----
+Repatable_Key:
+ - Value1
+ - Value2
+----
+
+Such options will be expanded to the following fluent-bit config snippet:
+
+[source]
+----
+Repeatable_Key Value1
+Repeatable_Key Value2
+----
+
+If only a single value needs to be configured for a repeatable option, the option can be given with a string value:
+
+[source,yaml]
+----
+Repeatable_Key: Value1
+----
+
+[IMPORTANT]
+====
+The component doesn't have any way to validate whether fluent-bit options are repeatable or not.
+Therefore, the component will treat any option with an array value as a repeatable option.
+
+It's the user's responsibility to ensure that they only use array values for fluent-bit options which are repeatable.
+====
+
 == `config.service`
 
 [horizontal]
@@ -210,4 +244,21 @@ config:
       Name: modify
       Match: '*'
       Add: "syn_cluster_name ${cluster:name}"
+----
+
+[source,yaml]
+----
+# Configure repeatable options.
+#
+# This example configures the `systemd` input plugin to pick up logs from
+# both the kubelet and docker units.
+config:
+  inputs:
+    systemd:
+      Name: systemd
+      Tag: host.*
+      Systemd_Filter:
+        - _SYSTEMD_UNIT=kubelet.service
+        - _SYSTEMD_UNIT=docker.service
+      Read_From_Tail: 'On'
 ----

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,7 +15,8 @@ The namespace in which to deploy this component.
 [horizontal]
 type:: dict
 
-The configuration for fluent-bit itself. Any fluent-bit options can be provided verbatim under the available sections.
+The configuration for fluent-bit itself. 
+Any fluent-bit options can be provided verbatim under the available sections.
 Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and `[PARSER]`  are supported.
 The respective keys are `service`, `inputs`, `outputs`, `filters`, and `parsers`.
 
@@ -119,7 +120,7 @@ The component doesn't configure any custom parsers.
 However, fluent-bit already provides a multitude of parsers in the docker image.
 
 Those parsers are made available by default as key `Parsers_File` in the service section is set to `parsers.conf`.
-The parsers provided by that file be inspected on https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[GitHub].
+The parsers provided by that file be inspected https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[in the docs].
 
 `config.parsers` should have one key per `[PARSER]` section that should be added to the fluent-bit configuration file.
 Each key of `config.parsers` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,18 +15,14 @@ The namespace in which to deploy this component.
 [horizontal]
 type:: dict
 
-The configuration for fluent-bit itself. Any fluent-bit options can be
-provided verbatim under the available sections.
-Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and
-`[PARSER]`  are supported.
-The respective keys are `service`, `inputs`, `outputs`, `filters`, and
-`parsers`.
+The configuration for fluent-bit itself. Any fluent-bit options can be provided verbatim under the available sections.
+Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and `[PARSER]`  are supported.
+The respective keys are `service`, `inputs`, `outputs`, `filters`, and `parsers`.
 
 [NOTE]
 ====
 Fluent-bit uses the strings 'On' and 'Off' for boolean configuration values.
-Make sure that you quote those strings to avoid them getting interpreted as
-booleans when the hierarchy YAML is parsed.
+Make sure that you quote those strings to avoid them getting interpreted as booleans when the hierarchy YAML is parsed.
 ====
 
 == `config.service`
@@ -36,17 +32,11 @@ type:: dict
 default:: `{'Flush': 1, 'Log_Level': 'info', 'Parsers_File': 'parsers.conf'}`
 
 Configure the fluent-bit service.
-See
-https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[the
-upstream documentation] for available configuration parameters.
+See https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[the upstream documentation] for available configuration parameters.
 
-Please note that 'HTTP_Server' shouldn't be disabled, as otherwise the
-container readiness and liveness probes will fail, and the pods will go into
-CrashLoopBackOff.
+Please note that 'HTTP_Server' shouldn't be disabled, as otherwise the container readiness and liveness probes will fail, and the pods will go into CrashLoopBackOff.
 
-The contents of this key will be reproduced verbatim (including capitalization
-of keys and values) in the fluent-bit configuration file in section
-`[SERVICE]`.
+The contents of this key will be reproduced verbatim (including capitalization of keys and values) in the fluent-bit configuration file in section `[SERVICE]`.
 
 == `config.inputs`
 
@@ -55,15 +45,10 @@ type:: dict
 default:: `{'containers': {'Name': 'tail', 'Path': '/var/log/containers/*.log', 'Parser': 'docker', 'Tag': 'kube.*', 'Mem_Buf_Limit': '5MB', 'Skip_Long_lines': 'On'}, 'systemd': {'Tag': 'host.*', 'Systemd_Filter': '_SYSTEMD_UNIT=kubelet.service', 'Read_From_Tail': 'On'}}`
 
 Configure fluent-bit inputs.
-`config.inputs` should have one key per `[INPUT]` section that should be added
-to the fluent-bit configuration file.
-Each key of `config.inputs` should contain a dict holding the configuration
-values for the section which will be reproduced verbatim (including
-capitalization of keys and values).
-If the dict for a section doesn't have a key `Name`, the key for the section
-will be used as the plugin name for the section.
-This allows avoiding repetition, when it's unnecessary, while still supporting
-having multiple inputs using the same plugin.
+`config.inputs` should have one key per `[INPUT]` section that should be added to the fluent-bit configuration file.
+Each key of `config.inputs` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
+If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
+This allows avoiding repetition, when it's unnecessary, while still supporting having multiple inputs using the same plugin.
 
 == `config.filters`
 
@@ -72,15 +57,11 @@ type:: dict
 default:: `{'00_kubernetes:'{'Name': 'kubernetes', 'Match': 'kube.*', 'Merge_Log': 'On', 'Keep_Log': 'On', 'K8S-Logging.Parser': 'On', 'K8S-Logging.Exclude': 'On'}}`
 
 Configure fluent-bit filters.
-`config.filters` should have one key per `[FILTER]` section that should be
-added to the fluent-bit configuration file.
-Each key of `config.filters` should contain a dict holding the configuration
-values for the section which will be reproduced verbatim (including
+`config.filters` should have one key per `[FILTER]` section that should be added to the fluent-bit configuration file.
+Each key of `config.filters` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including
 capitalization of keys and values).
-If the dict for a section doesn't have a key `Name`, the key for the section
-will be used as the plugin name for the section.
-This allows avoiding repetition, when it's unnecessary, while still supporting
-having multiple filters using the same plugin.
+If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
+This allows avoiding repetition, when it's unnecessary, while still supporting having multiple filters using the same plugin.
 
 NOTE: Please note that filter order matters to fluent-bit.
 The component will always output filters sorted by their keys.
@@ -95,22 +76,14 @@ default:: `{}`
 
 Configure fluent-bit parsers.
 The component doesn't configure any custom parsers.
-However, fluent-bit already provides a multitude of parsers in the docker
-image.
-Those parsers are made available by default as key `Parsers_File` in the
-service section is set to `parsers.conf`.
-The parsers provided by that file be inspected on
-https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[GitHub].
+However, fluent-bit already provides a multitude of parsers in the docker image.
+Those parsers are made available by default as key `Parsers_File` in the service section is set to `parsers.conf`.
+The parsers provided by that file be inspected on https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[GitHub].
 
-`config.parsers` should have one key per `[PARSER]` section that should be
-added to the fluent-bit configuration file.
-Each key of `config.parsers` should contain a dict holding the configuration
-values for the section which will be reproduced verbatim (including
-capitalization of keys and values).
-If the dict for a section doesn't have a key `Name`, the key for the section
-will be used as the plugin name for the section.
-This allows avoiding repetition, when it's unnecessary, while still supporting
-having multiple parsers using the same plugin.
+`config.parsers` should have one key per `[PARSER]` section that should be added to the fluent-bit configuration file.
+Each key of `config.parsers` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
+If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
+This allows avoiding repetition, when it's unnecessary, while still supporting having multiple parsers using the same plugin.
 
 == `config.outputs`
 
@@ -119,18 +92,13 @@ type:: dict
 default:: `{}`
 
 Configure fluent-bit outputs.
-The component defaults don't provide any outputs, as the component can't know
-where logs should be sent.
+The component defaults don't provide any outputs, as the component can't know where logs should be sent.
 
-`config.outputs` should have one key per `[OUTPUT]` section that should be
-added to the fluent-bit configuration file.
-Each key of `config.outputs` should contain a dict holding the configuration
-values for the section which will be reproduced verbatim (including
+`config.outputs` should have one key per `[OUTPUT]` section that should be added to the fluent-bit configuration file.
+Each key of `config.outputs` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including
 capitalization of keys and values).
-If the dict for a section doesn't have a key `Name`, the key for the section
-will be used as the plugin name for the section.
-This allows avoiding repetition, when it's unnecessary, while still supporting
-having multiple outputs using the same plugin.
+If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
+This allows avoiding repetition, when it's unnecessary, while still supporting having multiple outputs using the same plugin.
 
 == `annotations`
 
@@ -142,9 +110,7 @@ Annotations for the fluent-bit pods.
 
 By default annotation `fluentbit.io/exclude: 'true'` is set.
 This annotation ensures that fluent-bit doesn't process its own logs.
-This allows increasing the fluent-bit log level without having to worry about
-creating an exponential amount of logs, which could happen otherwise, as
-higher log levels will reproduce each processed message to `stdout`.
+This allows increasing the fluent-bit log level without having to worry about creating an exponential amount of logs, which could happen otherwise, as higher log levels will reproduce each processed message to `stdout`.
 
 == `psp_enabled`
 
@@ -170,9 +136,7 @@ default:: `2020`
 
 Configures the port on which fluent-bit exposes its metrics.
 
-This value is also injected into the fluent-bit configuration file in section
-`[SERVICE]` as the value for key `HTTP_Port`, unless `HTTP_Port` is explicitly
-set in `config.service`.
+This value is also injected into the fluent-bit configuration file in section `[SERVICE]` as the value for key `HTTP_Port`, unless `HTTP_Port` is explicitly set in `config.service`.
 
 == `tolerations`
 

--- a/postprocess/patch_helm_output.jsonnet
+++ b/postprocess/patch_helm_output.jsonnet
@@ -58,7 +58,7 @@ local fixup_obj(obj) =
 
 local fixup(obj_file) =
   local objs = std.prune(com.yaml_load_all(obj_file));
-  [fixup_obj(obj) for obj in objs];
+  [ fixup_obj(obj) for obj in objs ];
 
 {
   [stem(elem)]: fixup(input_file(elem))


### PR DESCRIPTION
Implement support for repeatable config options

Repeatable config options can now be specified in the component parameters as

```
Option:
  - Value1
  - Value2
```

These arrays will be transformed into the following fluentbit config entries

```
Option Value1
Option Value2
```

Repeatable options can still be given as `Option: Value1` if a single repetition is wanted.

Note that the component does this for any option, it's the user's responsibility to only specify repeated values for config options which are repeatable.

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
