### PR TITLE
Configure custom parsers in separate file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.1]
+### Fixed
+- Configure custom parsers in separate file ([#13])
+
 ## [v1.0.0]
 ### Added
 
@@ -28,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ensure filters are added to fluent-bit config in predictable order ([#6])
 
 [Unreleased]: https://github.com/projectsyn/component-fluentbit/compare/v1.0.0...HEAD
+[v1.0.1]: https://github.com/projectsyn/component-fluentbit/releases/tag/v1.0.1
 [v1.0.0]: https://github.com/projectsyn/component-fluentbit/releases/tag/v1.0.0
 
 [#1]: https://github.com/projectsyn/component-fluentbit/pull/1
@@ -39,3 +44,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#9]: https://github.com/projectsyn/component-fluentbit/pull/9
 [#10]: https://github.com/projectsyn/component-fluentbit/pull/10
 [#11]: https://github.com/projectsyn/component-fluentbit/pull/11
+[#13]: https://github.com/projectsyn/component-fluentbit/pull/13

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,7 +7,6 @@ parameters:
       service:
         Flush: 1
         Log_Level: info
-        Parsers_File: parsers.conf
       # If key Name (specifying the plugin) doesn't exist for an entry, the
       # entry's key is used as the plugin name. This allows having multiple
       # tail inputs for example. This is true for inputs, outputs, parsers and

--- a/class/fluentbit.yml
+++ b/class/fluentbit.yml
@@ -40,3 +40,9 @@ parameters:
         helm_params:
           namespace: ${fluentbit:namespace}
           name_template: fluent-bit
+  commodore:
+    postprocess:
+      filters:
+        - type: jsonnet
+          path: fluentbit/01_fluentbit_helmchart/fluent-bit/templates
+          filter: postprocess/patch_helm_output.jsonnet

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -140,6 +140,7 @@ local configmap = kube.ConfigMap(params.configMapName) {
 };
 
 {
+  '00_namespace': kube.Namespace(params.namespace),
   '10_custom_config': configmap,
   [if params.monitoring.enabled then '20_service_monitor']:
     kube._Object('monitoring.coreos.com/v1', 'ServiceMonitor', 'fluent-bit') {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -1,3 +1,4 @@
+local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
@@ -71,13 +72,52 @@ local filters = std.join('\n', [
   for elem in std.sort(std.objectFields(params.config.filters))
 ]);
 
-local serviceCfg = {
-  Daemon: 'Off',
-  Plugins_File: 'plugins.conf',
-  HTTP_Listen: '0.0.0.0',
-  HTTP_Server: 'On',
-  HTTP_Port: params.monitoring.metricsPort,
-} + params.config.service;
+local userParsersFile =
+  local userParsers = com.getValueOrDefault(
+    params.config.service,
+    'Parsers_File',
+    []
+  );
+  if std.isArray(userParsers) then
+    userParsers
+  else
+    [ userParsers ];
+
+local customParsersFragment =
+  if std.length(parsers) > 0 then
+    {
+      Parsers_File+: [
+        'custom_parsers.conf',
+      ],
+    }
+  else
+    {};
+
+local serviceCfg =
+  {
+    Daemon: 'Off',
+    Plugins_File: 'plugins.conf',
+    // Default configuration: always use fluentbit default parsers.conf
+    Parsers_File:
+      [ 'parsers.conf' ] +
+      // Add in any parser files configured by the user.
+      userParsersFile,
+    HTTP_Listen: '0.0.0.0',
+    HTTP_Server: 'On',
+    HTTP_Port: params.monitoring.metricsPort,
+  } +
+  // Remove Parsers_File config from user provided service config,
+  // we already add any Parsers_File configs provided by the user in the
+  // dict above.
+  std.prune(params.config.service { Parsers_File: null }) +
+  // Add Parsers_File entry for custom_parsers.conf, if any parsers are
+  // defined in the config hierarchy.
+  customParsersFragment +
+  // finally, deduplicate Parsers_File array
+  {
+    Parsers_File: std.set(super.Parsers_File),
+  };
+
 
 local service = render_fluentbit_cfg('SERVICE', '', serviceCfg);
 
@@ -94,8 +134,8 @@ local configmap = kube.ConfigMap(params.configMapName) {
     },
   },
   data: {
-    'fluent-bit.conf': std.join('\n', [ service, parsers, filters, inputs, outputs ]),
-    'custom_parsers.conf': '',
+    'fluent-bit.conf': std.join('\n', [ service, filters, inputs, outputs ]),
+    'custom_parsers.conf': parsers,
   },
 };
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -15,7 +15,7 @@ The namespace in which to deploy this component.
 [horizontal]
 type:: dict
 
-The configuration for fluent-bit itself. 
+The configuration for fluent-bit itself.
 Any fluent-bit options can be provided verbatim under the available sections.
 Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and `[PARSER]`  are supported.
 The respective keys are `service`, `inputs`, `outputs`, `filters`, and `parsers`.
@@ -64,7 +64,7 @@ It's the user's responsibility to ensure that they only use array values for flu
 
 [horizontal]
 type:: dict
-default:: `{'Flush': 1, 'Log_Level': 'info', 'Parsers_File': 'parsers.conf'}`
+default:: `{'Flush': 1, 'Log_Level': 'info'}`
 
 Configure the fluent-bit service.
 See https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[the upstream documentation] for available configuration parameters.
@@ -119,10 +119,11 @@ Configure fluent-bit parsers.
 The component doesn't configure any custom parsers.
 However, fluent-bit already provides a multitude of parsers in the docker image.
 
-Those parsers are made available by default as key `Parsers_File` in the service section is set to `parsers.conf`.
+The component will always add line `Parsers_File parsers.conf` in the main fluent-bit config to make the default parsers available.
 The parsers provided by that file be inspected https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file#config_section[in the docs].
 
-`config.parsers` should have one key per `[PARSER]` section that should be added to the fluent-bit configuration file.
+`config.parsers` should have one key per `[PARSER]` section that will be rendered into the fluent-bit ConfigMap in `custom_parsers.conf`.
+If `config.parsers` contains at least one entry, the component will add line `Parsers_File custom_parsers.conf` to the main fluent-bit config file.
 Each key of `config.parsers` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
 
 If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,4 +1,0 @@
-filters:
-  - output_path: fluentbit/01_fluentbit_helmchart/fluent-bit/templates
-    type: jsonnet
-    filter: patch_helm_output.jsonnet

--- a/postprocess/filters.yml
+++ b/postprocess/filters.yml
@@ -1,10 +1,4 @@
 filters:
-  - path: fluentbit/01_fluentbit_helmchart/fluent-bit/templates
-    type: builtin
-    filter: helm_namespace
-    filterargs:
-      namespace: ${fluentbit:namespace}
-      create_namespace: "true"
   - output_path: fluentbit/01_fluentbit_helmchart/fluent-bit/templates
     type: jsonnet
     filter: patch_helm_output.jsonnet


### PR DESCRIPTION
This commit renders custom parsers (if any) to file `custom_parsers.conf` in the fluent-bit ConfigMap.

The component will also add `Parsers_File custom_parsers.conf` to the main configuration if at least one custom parser is configured.

Fixes #12.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Update the ./CHANGELOG.md.
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
