### PR TITLE
escape strings with multiple asterisks

### DIFF
--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -77,7 +77,7 @@ The contents of this key will be reproduced verbatim (including capitalization o
 
 [horizontal]
 type:: dict
-default:: `{'containers': {'Name': 'tail', 'Path': '/var/log/containers/*.log', 'Parser': 'docker', 'Tag': 'kube.*', 'Mem_Buf_Limit': '5MB', 'Skip_Long_lines': 'On'}, 'systemd': {'Tag': 'host.*', 'Systemd_Filter': '_SYSTEMD_UNIT=kubelet.service', 'Read_From_Tail': 'On'}}`
+default:: `+{'containers': {'Name': 'tail', 'Path': '/var/log/containers/*.log', 'Parser': 'docker', 'Tag': 'kube.*', 'Mem_Buf_Limit': '5MB', 'Skip_Long_lines': 'On'}, 'systemd': {'Tag': 'host.*', 'Systemd_Filter': '_SYSTEMD_UNIT=kubelet.service', 'Read_From_Tail': 'On'}}+`
 
 Configure fluent-bit inputs.
 `config.inputs` should have one key per `[INPUT]` section that should be added to the fluent-bit configuration file.


### PR DESCRIPTION
According to https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#literals-and-source-code adding the plus sign to the backtick-block should make it an inline literal monospace

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [ ] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [ ] Update the ./CHANGELOG.md.
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
