### PR TITLE
Add parameter to add generic helm values

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -65,3 +65,20 @@ parameters:
       fluent_bit:
         image: docker.io/fluent/fluent-bit
         tag: 1.9.1
+    helm_values:
+      podAnnotations: ${fluentbit:annotations}
+      image:
+        repository: ${fluentbit:images:fluent_bit:image}
+        tag: ${fluentbit:images:fluent_bit:tag}
+      existingConfigMap: ${fluentbit:configMapName}
+      service:
+        port: ${fluentbit:monitoring:metricsPort}
+      podSecurityPolicy:
+        create: ${fluentbit:psp_enabled}
+      serviceMonitor:
+        enabled: ${fluentbit:monitoring:enabled}
+      prometheusRule:
+        enabled: false
+      tolerations: ${fluentbit:tolerations}
+      extraVolumes: ${fluentbit:extraVolumes}
+      extraVolumeMounts: ${fluentbit:extraVolumeMounts}

--- a/class/fluentbit.yml
+++ b/class/fluentbit.yml
@@ -20,23 +20,7 @@ parameters:
         output_type: yaml
         input_paths:
           - fluentbit/helmcharts/fluent-bit
-        helm_values:
-          podAnnotations: ${fluentbit:annotations}
-          image:
-            repository: ${fluentbit:images:fluent_bit:image}
-            tag: ${fluentbit:images:fluent_bit:tag}
-          existingConfigMap: ${fluentbit:configMapName}
-          service:
-            port: ${fluentbit:monitoring:metricsPort}
-          podSecurityPolicy:
-            create: ${fluentbit:psp_enabled}
-          serviceMonitor:
-            enabled: ${fluentbit:monitoring:enabled}
-          prometheusRule:
-            enabled: false
-          tolerations: ${fluentbit:tolerations}
-          extraVolumes: ${fluentbit:extraVolumes}
-          extraVolumeMounts: ${fluentbit:extraVolumeMounts}
+        helm_values: ${fluentbit:helm_values}
         helm_params:
           namespace: ${fluentbit:namespace}
           name_template: fluent-bit

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -224,6 +224,17 @@ default:: `docker.io/fluent/fluent-bit`
 type:: string
 default:: `1.7.2`
 
+== `helm_values`
+
+[horizontal]
+type:: dict
+default:: see `defaults.yml`
+
+All helm_values are passed to the helm chart.
+This allows to configure all https://github.com/fluent/helm-charts/blob/main/charts/fluentd/values.yaml[fluentbit helm chart values].
+
+Note that it's your own liability to make sure you don't break stuff by overwriting values here!
+
 == Example
 
 [source,yaml]


### PR DESCRIPTION
Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>

This new parameter allow setting any parameter supported by the upstream helm chart.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
