### PR TITLE
Add support for configuring multiline parsers

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,11 +21,11 @@ parameters:
           Parser: docker
           Tag: kube.*
           Mem_Buf_Limit: 5MB
-          Skip_Long_lines: 'On'
+          Skip_Long_lines: "On"
         systemd:
           Tag: host.*
           Systemd_Filter: _SYSTEMD_UNIT=kubelet.service
-          Read_From_Tail: 'On'
+          Read_From_Tail: "On"
       # We don't define any outputs by default, as we have no idea where logs
       # should be shipped.
       outputs: {}
@@ -34,17 +34,18 @@ parameters:
       # included parsers. The set of available parsers can be found at
       # https://github.com/fluent/fluent-bit/blob/master/conf/parsers.conf
       parsers: {}
+      multiline_parsers: {}
       # The kubernetes filter is almost always wanted
       filters:
         00_kubernetes:
           Name: kubernetes
           Match: kube.*
           # Extract log elements and add them as top-level keys
-          Merge_Log: 'On'
+          Merge_Log: "On"
           # Keep the original log message
-          Keep_Log: 'On'
-          K8S-Logging.Parser: 'On'
-          K8S-Logging.Exclude: 'On'
+          Keep_Log: "On"
+          K8S-Logging.Parser: "On"
+          K8S-Logging.Exclude: "On"
     # fluent-bit extra annotations
     annotations:
       fluentbit.io/exclude: "true"

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -17,8 +17,8 @@ type:: dict
 
 The configuration for fluent-bit itself.
 Any fluent-bit options can be provided verbatim under the available sections.
-Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, and `[PARSER]`  are supported.
-The respective keys are `service`, `inputs`, `outputs`, `filters`, and `parsers`.
+Currently sections `[SERVICE]`, `[INPUT]`, `[OUTPUT]`, `[FILTER]`, `[PARSER]` and `[MULTILINE_PARSER]` are supported.
+The respective keys are `service`, `inputs`, `outputs`, `filters`, `parsers` and `multiline_parsers`.
 
 [NOTE]
 ====
@@ -132,6 +132,22 @@ Each key of `config.parsers` should contain a dict holding the configuration val
 
 If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
 This allows avoiding repetition, when it's unnecessary, while still supporting having multiple parsers using the same plugin.
+
+== `config.multiline_parsers`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Configure fluent-bit multiline parsers.
+The component doesn't configure any custom multiline parsers.
+
+`config.multiline_parsers` should have one key per `[MULTILINE_PARSER]` section that will be rendered into the fluent-bit ConfigMap in `custom_parsers.conf`.
+If `config.multiline_parsers` contains at least one entry, the component will add line `Parsers_File custom_parsers.conf` to the main fluent-bit config file.
+Each key of `config.multiline_parsers` should contain a dict holding the configuration values for the section which will be reproduced verbatim (including capitalization of keys and values).
+
+If the dict for a section doesn't have a key `Name`, the key for the section will be used as the plugin name for the section.
+This allows avoiding repetition, when it's unnecessary, while still supporting having multiple multiline parsers using the same plugin.
 
 == `config.outputs`
 


### PR DESCRIPTION
This PR adds support for configuring multiline parsers.

## Checklist

- [X] PR contains a single logical change (to build a better changelog).
- [X] Update the documentation.
- [X] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [X] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
